### PR TITLE
Update domain file to 2.8

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -426,94 +426,100 @@ actions:
 - action_check_claim_balance
 forms:
   quote_form:
-    AA_quote_insurance_type:
-    - entity: quote_insurance_type
-      type: from_entity
-    - not_intent: stop
-      type: from_text
-    quote_number_persons:
-    - entity: quote_number_persons
-      type: from_entity
-    - not_intent: stop
-      type: from_text
-    quote_state:
-    - entity: state
-      type: from_entity
-    - not_intent: stop
-      type: from_text
+    required_slots:
+      AA_quote_insurance_type:
+      - entity: quote_insurance_type
+        type: from_entity
+      - not_intent: stop
+        type: from_text
+      quote_number_persons:
+      - entity: quote_number_persons
+        type: from_entity
+      - not_intent: stop
+        type: from_text
+      quote_state:
+      - entity: state
+        type: from_entity
+      - not_intent: stop
+        type: from_text
   get_claim_form:
-    claim_id:
-    - entity: claim_id
-      type: from_entity
-    - type: from_text
+    required_slots:
+      claim_id:
+      - entity: claim_id
+        type: from_entity
+      - type: from_text
   change_address_form:
-    address_city:
-    - not_intent: stop
-      type: from_text
-    address_state:
-    - entity: state
-      type: from_entity
-    address_street:
-    - not_intent: stop
-      type: from_text
-    address_zip:
-    - not_intent: stop
-      type: from_text
+    required_slots:
+      address_city:
+      - not_intent: stop
+        type: from_text
+      address_state:
+      - entity: state
+        type: from_entity
+      address_street:
+      - not_intent: stop
+        type: from_text
+      address_zip:
+      - not_intent: stop
+        type: from_text
   pay_claim_form:
-    claim_id:
-    - entity: claim_id
-      type: from_entity
-    - not_intent:
-      - uncertain
-      - deny
-      - claim_status
-      type: from_text
-    claim_pay_amount:
-    - entity: amount-of-money
-      type: from_entity
-    - entity: number
-      type: from_entity
-    - not_intent:
-      - uncertain
-      - deny
-      type: from_text
-    confirm_payment:
-    - intent: affirm
-      type: from_intent
-      value: true
-    - intent: deny
-      type: from_intent
-      value: false
+    required_slots:
+      claim_id:
+      - entity: claim_id
+        type: from_entity
+      - not_intent:
+        - uncertain
+        - deny
+        - claim_status
+        type: from_text
+      claim_pay_amount:
+      - entity: amount-of-money
+        type: from_entity
+      - entity: number
+        type: from_entity
+      - not_intent:
+        - uncertain
+        - deny
+        type: from_text
+      confirm_payment:
+      - intent: affirm
+        type: from_intent
+        value: true
+      - intent: deny
+        type: from_intent
+        value: false
   scroll_claims_form:
-    scroll_claims:
-    - entity: scroll_claims
-      not_intent: uncertain
-      type: from_entity
-    - type: from_text
+    required_slots:
+      scroll_claims:
+      - entity: scroll_claims
+        not_intent: uncertain
+        type: from_entity
+      - type: from_text
   file_new_claim_form:
-    AA_quote_insurance_type:
-    - entity: quote_insurance_type
-      type: from_entity
-    - not_intent: stop
-      type: from_text
-    claim_amount_submit:
-    - entity: number
-      not_intent: stop
-      type: from_entity
-    - entity: amount-of-money
-      not_intent: stop
-      type: from_entity
-    - intent: inform
-      type: from_text
-    confirm_file_new_claim:
-    - intent: affirm
-      type: from_intent
-      value: yes
-    - intent: deny
-      type: from_intent
-      value: no
-    - intent:
-      - inform
-      - claim_status_form
-      type: from_text
+    required_slots:
+      AA_quote_insurance_type:
+      - entity: quote_insurance_type
+        type: from_entity
+      - not_intent: stop
+        type: from_text
+      claim_amount_submit:
+      - entity: number
+        not_intent: stop
+        type: from_entity
+      - entity: amount-of-money
+        not_intent: stop
+        type: from_entity
+      - intent: inform
+        type: from_text
+      confirm_file_new_claim:
+      - intent: affirm
+        type: from_intent
+        value: yes
+      - intent: deny
+        type: from_intent
+        value: no
+      - intent:
+        - inform
+        - claim_status_form
+        type: from_text
 e2e_actions: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-rasa==2.3.1
-rasa-sdk==2.3.1
+rasa==2.8.1
+rasa-sdk==2.8.1


### PR DESCRIPTION
The research team [wants to add this repo to the core policy regression tests](https://github.com/RasaHQ/rasa/issues/8676). To do that we need to update the domain file to be compatible with Rasa 2.8.

Currently the form definitions in the domain.yml do not use the `required_slots` key. Not using the key was marked as deprecated in Rasa 2.6. As we move to 3.0 and start removing deprecated behaviors, not using the `required_slots` keys will cause training to fail on YAML validation.

This PR adds the `required_slots` key to all form definitions in the domain.yml. This should not change the behavior of the bot.